### PR TITLE
Add a functionnality for Lustre to choose specific OSTs or all available OSTs as starting OST for testfile in POSIX mode with separate files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,20 @@ AS_IF([test "x$with_lustre" != xno], [
                         AC_MSG_FAILURE([--with-lustre was given, <lustre/lustre_user.h> not found])
                 fi
         ])
+        AC_CHECK_HEADERS([lustre/liblustreapi.h], [AC_DEFINE([HAVE_LUSTREAPI],[1],[Have LustreAPI]) with_lustreapi=true], [
+                if test "x$with_lustre" != xcheck; then
+                        AC_MSG_ERROR([--with-lustre was given, <lustre/liblustreapi.h> not found])
+                fi
+        ])
+
+])
+AM_CONDITIONAL([USE_LUSTRE], [test x$with_lustre = xyes])
+AM_COND_IF([USE_LUSTRE],[
+        AC_DEFINE([USE_LUSTRE], [], [Build LUSTRE support])
+])
+AM_CONDITIONAL([USE_LUSTREAPI], [test x$with_lustreapi = xtrue])
+AM_COND_IF([USE_LUSTREAPI],[
+        AC_DEFINE([USE_LUSTREAPI], [], [Build LUSTRE support])
 ])
 
 # POSIX IO support

--- a/doc/USER_GUIDE
+++ b/doc/USER_GUIDE
@@ -341,6 +341,14 @@ LUSTRE-SPECIFIC:
 
   * lustreIgnoreLocks    - disable lustre range locking [0]
 
+  * lustreUseAllOsts     - set specifically OSTs as starting OST for the test file(s) [default=-1] :
+                              * -1 = let Lustre choose OST
+                              *  0 = use all available OSTs of Lustre file system as starting OSTs
+                              *  n = use the first n OSTs available of Lustre file system as starting OSTs
+                              *  [l-m,n] = use the specified OSTs as starting OSTs
+                           Note: if Lustre file system has 4 OSTs, the option "lustreStripeCount=1,lustreUseAllOsts=4"
+                                 will write one file one each OST
+
 
 ***********************
 * 5. VERBOSITY LEVELS *

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,9 +7,14 @@ ior_SOURCES = ior.c utilities.c parse_options.c
 ior_SOURCES += ior.h utilities.h parse_options.h aiori.h iordef.h
 ior_LDADD =
 
+if USE_LUSTREAPI
+ior_LDADD += -llustreapi
+endif
+
 if USE_POSIX_AIORI
 ior_SOURCES += aiori-POSIX.c
 endif
+
 if USE_MPIIO_AIORI
 ior_SOURCES += aiori-MPIIO.c
 endif

--- a/src/ior.c
+++ b/src/ior.c
@@ -187,6 +187,7 @@ void init_IOR_Param_t(IOR_param_t * p)
         p->testComm = MPI_COMM_WORLD;
         p->setAlignment = 1;
         p->lustre_start_ost = -1;
+        p->lustre_use_all_osts = -1;
 }
 
 /*
@@ -1460,7 +1461,7 @@ static void ShowTestInfo(IOR_param_t *params)
  */
 static void ShowSetup(IOR_param_t *params)
 {
-
+        int i;
         if (strcmp(params->debug, "") != 0) {
                 printf("\n*** DEBUG MODE ***\n");
                 printf("*** %s ***\n\n", params->debug);
@@ -1527,6 +1528,22 @@ static void ShowSetup(IOR_param_t *params)
                 } else {
                         printf("\t      stripe count = %d\n",
                                params->lustre_stripe_count);
+                }
+                if (params->lustre_use_all_osts == -1) {
+                        printf("\t    scatter to OSTs= false\n");
+                } else {
+                        if(params->lustre_use_all_osts == 0) {
+                                printf("\t   scatter to OSTs = all\n");
+                        } else {
+                                printf("\t   scatter to OSTs = %d\n",params->lustre_use_all_osts);
+                                if(params->lustre_ost_list[0] >= 0) {
+                                        printf("\t    OSTs list      = [%d",params->lustre_ost_list[0]);
+                                        for(i=1;i<params->lustre_use_all_osts;i++) {
+                                                printf(",%d",params->lustre_ost_list[i]);
+                                        }
+                                        printf("]");
+                                }
+                        }
                 }
         }
 #endif /* HAVE_LUSTRE_LUSTRE_USER_H */

--- a/src/ior.h
+++ b/src/ior.h
@@ -125,6 +125,8 @@ typedef struct
     int lustre_start_ost;
     int lustre_set_striping;         /* flag that we need to set lustre striping */
     int lustre_ignore_locks;
+    int lustre_use_all_osts;
+    int lustre_ost_list[MAX_OST_COUNT];    
 
     int id;                          /* test's unique ID */
     int intraTestBarriers;           /* barriers between open/op and op/close */

--- a/src/iordef.h
+++ b/src/iordef.h
@@ -108,6 +108,9 @@ extern int verbose;                            /* verbose output */
 #ifndef PATH_MAX
 #define PATH_MAX           4096
 #endif
+#ifndef MAX_OST_COUNT
+#define MAX_OST_COUNT      1024
+#endif
 
 #define DELIMITERS         " \t\r\n="          /* ReadScript() */
 #define FILENAME_DELIMITER '@'                 /* ParseFileName() */

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -27,5 +27,6 @@ void DumpBuffer(void *, size_t);
 void SeedRandGen(MPI_Comm);
 void SetHints (MPI_Info *, char *);
 void ShowHints (MPI_Info *);
+int get_active_ost_list(const char* path, int *ost_count, int *ost_list);
 
 #endif  /* !_UTILITIES_H */


### PR DESCRIPTION
Add a functionnality for Lustre to choose specific OSTs or all available OSTs as starting OST for testfile in POSIX mode with separate files.

The main need for this functionnality is the possibility to bench all available OST in the Lustre file system

Changes:
- Add in configure file the test for LustreAPI
- Add an option for Lustre "lustreUseAllOsts" which activate the functionnality and give the choice of the OST used
- Add two functions in utilities.c : 
  - nodesete : read the OST list
  - get_active_ost_list : retrieve all available OSTs in the Lustre file system from the path of the testfiles
- Add the necessary lines in the user guide 
