### PR TITLE
Teach IOR about GPFS hints (gpfs_fcntl)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AX_PROG_CC_MPI
 # Checks for libraries.
 
 # Checks for header files.
-AC_CHECK_HEADERS([fcntl.h libintl.h stdlib.h string.h strings.h sys/ioctl.h sys/param.h sys/statfs.h sys/statvfs.h sys/time.h unistd.h wchar.h])
+AC_CHECK_HEADERS([fcntl.h libintl.h stdlib.h string.h strings.h sys/ioctl.h sys/param.h sys/statfs.h sys/statvfs.h sys/time.h unistd.h wchar.h gpfs.h gpfs_fcntl.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T

--- a/doc/USER_GUIDE
+++ b/doc/USER_GUIDE
@@ -341,6 +341,13 @@ LUSTRE-SPECIFIC:
 
   * lustreIgnoreLocks    - disable lustre range locking [0]
 
+GPFS-SPECIFIC:
+================
+  * gpfsHintAccess       - use gpfs_fcntl hints to pre-declare accesses
+
+  * gpfsReleaseToken     - immediately after opening or creating file, release
+			   all locks.  Might help mitigate lock-revocation
+			   traffic when many proceses write/read to same file.
 
 ***********************
 * 5. VERBOSITY LEVELS *

--- a/src/ior.c
+++ b/src/ior.c
@@ -1601,6 +1601,10 @@ static void ShowTest(IOR_param_t * test)
                 test->setTimeStampSignature);
         fprintf(stdout, "\t%s=%d\n", "collective", test->collective);
         fprintf(stdout, "\t%s=%lld", "segmentCount", test->segmentCount);
+#ifdef HAVE_GPFS_FCNTL_H
+        fprintf(stdout, "\t%s=%d\n", "gpfsHintAccess", test->gpfs_hint_access);
+        fprintf(stdout, "\t%s=%d\n", "gpfsReleaseToken", test->gpfs_release_token);
+#endif
         if (strcmp(test->api, "HDF5") == 0) {
                 fprintf(stdout, " (datasets)");
         }

--- a/src/ior.h
+++ b/src/ior.h
@@ -126,6 +126,11 @@ typedef struct
     int lustre_set_striping;         /* flag that we need to set lustre striping */
     int lustre_ignore_locks;
 
+    /* gpfs variables */
+    int gpfs_hint_access;          /* use gpfs "access range" hint */
+    int gpfs_release_token;        /* immediately release GPFS tokens after
+                                      creating or opening a file */
+
     int id;                          /* test's unique ID */
     int intraTestBarriers;           /* barriers between open/op and op/close */
 } IOR_param_t;

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -263,6 +263,16 @@ void DecodeDirective(char *line, IOR_param_t *params)
                 ERR("ior was not compiled with Lustre support");
 #endif
                 params->lustre_ignore_locks = atoi(value);
+        } else if (strcasecmp(option, "gpfshintaccess") == 0) {
+#ifndef HAVE_GPFS_FCNTL_H
+                ERR("ior was not compiled with GPFS hint support");
+#endif
+                params->gpfs_hint_access = atoi(value);
+        } else if (strcasecmp(option, "gpfsreleasetoken") == 0) {
+#ifndef HAVE_GPFS_FCNTL_H
+                ERR("ior was not compiled with GPFS hint support");
+#endif
+                params->gpfs_release_token = atoi(value);
         } else if (strcasecmp(option, "numtasks") == 0) {
                 params->numTasks = atoi(value);
 		RecalculateExpectedFileSize(params);


### PR DESCRIPTION
GPFS supports a "gpfs_fcntl" method for hinting various things,
including "i'm about to write this block of data".  Let's see if, for
the cost of a few system calls, we can wrangle the GPFS locking system
into allowing concurrent access with less overhead. (new IOR parameter
gpfsHintAccess)

Also, drop all locks on a file immediately after open/creation in the
shared file case, since we know all processes will touch unique regions
of the file.  It may or may not be a good idea to release all file locks
after opening.  Processes will then have to re-acquire locks already
held.   (new IOR parameter gpfsReleaseToken)
