### PR TITLE
clean up MPI resources

### DIFF
--- a/src/aiori-MPIIO.c
+++ b/src/aiori-MPIIO.c
@@ -146,6 +146,8 @@ static void *MPIIO_Open(char *testFileName, IOR_param_t * param)
 
         /* show hints actually attached to file handle */
         if (rank == 0 && param->showHints) {
+                if (mpiHints != MPI_INFO_NULL)
+                        MPI_CHECK(MPI_Info_free(&mpiHints), "MPI_Info_free failed");
                 MPI_CHECK(MPI_File_get_info(*fd, &mpiHints),
                           "cannot get file info");
                 fprintf(stdout, "\nhints returned from opened file {\n");
@@ -206,6 +208,8 @@ static void *MPIIO_Open(char *testFileName, IOR_param_t * param)
                                             (MPI_Info) MPI_INFO_NULL),
                           "cannot set file view");
         }
+        if (mpiHints != MPI_INFO_NULL)
+                MPI_CHECK(MPI_Info_free(&mpiHints), "MPI_Info_free failed");
         return ((void *)fd);
 }
 

--- a/src/ior.c
+++ b/src/ior.c
@@ -1938,6 +1938,8 @@ static void TestIoSys(IOR_test_t *test)
                   "MPI_Group_range_incl() error");
         MPI_CHECK(MPI_Comm_create(MPI_COMM_WORLD, new_group, &testComm),
                   "MPI_Comm_create() error");
+        MPI_CHECK(MPI_Group_free(&orig_group), "MPI_Group_Free() error");
+        MPI_CHECK(MPI_Group_free(&new_group), "MPI_Group_Free() error");
         params->testComm = testComm;
         if (testComm == MPI_COMM_NULL) {
                 /* tasks not in the group do not participate in this test */


### PR DESCRIPTION
IOR was leaking a hint structure in MPI-IO case, and two groups in
common code.  I'm still seeing one group leak on Blue Gene, but cannot
find where that would be...
