### PR TITLE
A more MPI-IO friendly remove file

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -1254,6 +1254,18 @@ static void PrintRemoveTiming(double start, double finish, int rep)
 static void RemoveFile(char *testFileName, int filePerProc, IOR_param_t * test)
 {
         int tmpRankOffset;
+        char *strippedFileName;
+
+        /* consider a file with a ROMIO prefix: ufs:/path/to/file
+         * posix routines do not understand 'ufs:/path/to/file';  need
+         * '/path/to/file' instead. */
+        strippedFileName = strchr(testFileName, ':');
+        if (strippedFileName > testFileName + 1)
+                strippedFileName = strippedFileName + 1;
+        else
+                /* no prefix, so leave it alone */
+                strippedFileName = testFileName;
+
         if (filePerProc) {
                 /* in random tasks, delete own file */
                 if (test->reorderTasksRandom == TRUE) {
@@ -1261,7 +1273,7 @@ static void RemoveFile(char *testFileName, int filePerProc, IOR_param_t * test)
                         rankOffset = 0;
                         GetTestFileName(testFileName, test);
                 }
-                if (access(testFileName, F_OK) == 0) {
+                if (access(strippedFileName, F_OK) == 0) {
                         backend->delete(testFileName, test);
                 }
                 if (test->reorderTasksRandom == TRUE) {
@@ -1269,7 +1281,7 @@ static void RemoveFile(char *testFileName, int filePerProc, IOR_param_t * test)
                         GetTestFileName(testFileName, test);
                 }
         } else {
-                if ((rank == 0) && (access(testFileName, F_OK) == 0)) {
+                if ((rank == 0) && (access(strippedFileName, F_OK) == 0)) {
                         backend->delete(testFileName, test);
                 }
         }


### PR DESCRIPTION
MPI-IO allows prefxing file names with something-something: (e.g. pvfs2:
or bglockless:). These prefixed file names, however, do not make sense
to posix calls like access().  So, if we must use access(), strip the
prefix first.  Amended to handle the no-prefix case as well.  Reported
by Florin Isaila florin.isaila@gmail.com, who sent me a first draft
of this patch.
