### PR TITLE
more tolerant of whitepace in hintfile

### DIFF
--- a/src/utilities.c
+++ b/src/utilities.c
@@ -162,8 +162,8 @@ void ExtractHint(char *settingVal, char *valueVal, char *hintString)
 {
         char *settingPtr, *valuePtr, *tmpPtr1, *tmpPtr2;
 
-        settingPtr = (char *)strtok(hintString, "=");
-        valuePtr = (char *)strtok(NULL, " \t\r\n");
+        settingPtr = (char *)strtok(hintString, " =");
+        valuePtr = (char *)strtok(NULL, " =\t\r\n");
         tmpPtr1 = settingPtr;
         tmpPtr2 = (char *)strstr(settingPtr, "IOR_HINT__MPI__");
         if (tmpPtr1 == tmpPtr2) {


### PR DESCRIPTION
If a hintfile contains e.g. cb_buffer_size = 1234, IOR will try to set
the hint "cb_buffer_size " (note trailing space), a hint that no MPI
implementation actually supports.
