### PR TITLE
Basic support for non-POSIX backends

### DIFF
--- a/src/aiori-HDF5.c
+++ b/src/aiori-HDF5.c
@@ -98,8 +98,8 @@ static IOR_offset_t HDF5_GetFileSize(IOR_param_t *, MPI_Comm, char *);
 
 ior_aiori_t hdf5_aiori = {
         "HDF5",
-        POSIX_Init,
-        POSIX_Finalize,
+        NULL, /* no-op init, finalize */
+        NULL,
         HDF5_Create,
         HDF5_Open,
         HDF5_Xfer,

--- a/src/aiori-MPIIO.c
+++ b/src/aiori-MPIIO.c
@@ -46,8 +46,8 @@ static void MPIIO_Fsync(void *, IOR_param_t *);
 
 ior_aiori_t mpiio_aiori = {
         "MPIIO",
-        POSIX_Init,
-        POSIX_Finalize,
+        NULL, /* no-op init, finalize */
+        NULL,
         MPIIO_Create,
         MPIIO_Open,
         MPIIO_Xfer,

--- a/src/aiori-NCMPI.c
+++ b/src/aiori-NCMPI.c
@@ -62,8 +62,8 @@ static IOR_offset_t NCMPI_GetFileSize(IOR_param_t *, MPI_Comm, char *);
 
 ior_aiori_t ncmpi_aiori = {
         "NCMPI",
-        POSIX_Init,
-        POSIX_Finalize,
+        NULL, /* no-op init, finalize */
+        NULL,
         NCMPI_Create,
         NCMPI_Open,
         NCMPI_Xfer,

--- a/src/aiori-POSIX.c
+++ b/src/aiori-POSIX.c
@@ -70,8 +70,8 @@ static IOR_offset_t POSIX_GetFileSize(IOR_param_t *, MPI_Comm, char *);
 
 ior_aiori_t posix_aiori = {
         "POSIX",
-        POSIX_Init,
-        POSIX_Finalize,
+        NULL, /* no-op init, finalize */
+        NULL,
         POSIX_Create,
         POSIX_Open,
         POSIX_Xfer,
@@ -454,18 +454,6 @@ static IOR_offset_t POSIX_GetFileSize(IOR_param_t * test, MPI_Comm testComm,
         }
 
         return (aggFileSizeFromStat);
-}
-
-void POSIX_Init(IOR_param_t *test) {
-        /* no-op at the moment, though perhaps some of the POSIX-related setup
-         * code (such as mkdir's for the uniqueDir option) can go here in the
-         * future */
-}
-
-void POSIX_Finalize(IOR_param_t *test) {
-        /* no-op at the moment, though perhaps some of the POSIX-related
-         * teardown code (deleting test files/directories) can go here in the
-         * future */
 }
 
 int POSIX_Access(char *testFileName, int mode){

--- a/src/aiori.h
+++ b/src/aiori.h
@@ -78,9 +78,6 @@ ior_aiori_t ncmpi_aiori;
 IOR_offset_t MPIIO_GetFileSize(IOR_param_t * test, MPI_Comm testComm,
                                char *testFileName);
 
-void POSIX_Init(IOR_param_t *test);
-void POSIX_Finalize(IOR_param_t *test);
-
 int POSIX_Access(char *testFileName, int mode);
 int POSIX_Mkdir(char *dir, int mode);
 

--- a/src/ior.c
+++ b/src/ior.c
@@ -1973,7 +1973,8 @@ static void TestIoSys(IOR_test_t *test)
         hog_buf = HogMemory(params);
 
         /* do backend-specific initialization */
-        backend->init(params);
+        if (backend->init)
+                backend->init(params);
 
         startTime = GetTimeStamp();
 
@@ -2233,7 +2234,8 @@ static void TestIoSys(IOR_test_t *test)
         }
 
         /* do backend-specific finalization */
-        backend->finalize(params);
+        if (backend->finalize)
+                backend->finalize(params);
 
         MPI_CHECK(MPI_Comm_free(&testComm), "MPI_Comm_free() error");
 


### PR DESCRIPTION
This PR performs some simple refactoring and adds minimal functionality to enable the implementation of backends with files not mapped into the POSIX namespace. For example, talking directly to object storage systems or experimenting with new storage system interfaces such as ASG ("Towards a Unified Object Storage Foundation for Scalable Storage Systems", http://press3.mcs.anl.gov/iasds13/program/papers/) are, for the most part, made possible with this PR.

Expand the commit messages for a more detailed description of each change - essentially, some syscalls were moved into backend functions, and a dedicated init/finalize function was added. 

No changes in behavior to IOR and all of the existing backends were made.
