### PR TITLE
 	switched NCMPI write type to MPI_SIGNED_CHAR instead of MPI_BYTE to be compatible with parallel-netcdf 1.7.0

### DIFF
--- a/src/aiori-NCMPI.c
+++ b/src/aiori-NCMPI.c
@@ -279,24 +279,24 @@ static IOR_offset_t NCMPI_Xfer(int access, void *fd, IOR_size_t * buffer,
                 if (param->collective) {
                         NCMPI_CHECK(ncmpi_put_vara_all
                                     (*(int *)fd, var_id, offset, bufSize,
-                                     bufferPtr, length, MPI_BYTE),
+                                     bufferPtr, length, MPI_SIGNED_CHAR),
                                     "cannot write to data set");
                 } else {
                         NCMPI_CHECK(ncmpi_put_vara
                                     (*(int *)fd, var_id, offset, bufSize,
-                                     bufferPtr, length, MPI_BYTE),
+                                     bufferPtr, length, MPI_SIGNED_CHAR),
                                     "cannot write to data set");
                 }
         } else {                /* READ or CHECK */
                 if (param->collective == TRUE) {
                         NCMPI_CHECK(ncmpi_get_vara_all
                                     (*(int *)fd, var_id, offset, bufSize,
-                                     bufferPtr, length, MPI_BYTE),
+                                     bufferPtr, length, MPI_SIGNED_CHAR),
                                     "cannot read from data set");
                 } else {
                         NCMPI_CHECK(ncmpi_get_vara
                                     (*(int *)fd, var_id, offset, bufSize,
-                                     bufferPtr, length, MPI_BYTE),
+                                     bufferPtr, length, MPI_SIGNED_CHAR),
                                     "cannot read from data set");
                 }
         }


### PR DESCRIPTION
Newest parallel-netcdf release (1.7) changed default type to represent NC_BYTE from MPI_BYTE to MPI_SIGNED_CHAR. This has to be reflected in ior to allow NCMPI execution runs.